### PR TITLE
Date range defaults and live document total

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,21 @@ $ python setup.py test
 To crawl the comments, make sure you have a server setup, and then run:
 
 ```
-$ fcc index --endpoint=http://localhost:9200
+$ fcc index --endpoint=http://localhost:9200/
 ```
 
 This will take anywhere from 2-4 hours (or wont' work at all, if the API is down).
+
+To get a smaller subset of comments for testing, add `-g YYYY-MM-DD` to get comments submitted after the specified date:
+
+```
+$ fcc index --endpoint=http://localhost:9200/ -g 2017-06-01
+```
 
 I then take another pass on the data, appending "analysis" variables to all of the documents. This makes it a lot easier to spot trends in Kibana.
 
 To analyze the comments:
 
 ```
-$ fcc analyze --endpoint=http://localhost:9200
+$ fcc analyze --endpoint=http://localhost:9200/
 ```


### PR DESCRIPTION
get total document count from aggregation by proceeding name, where bucket value is 17-108

since both less than and greater than dates are required for query, use defaults if only one is specified:
- less than = now
- greater than = 2000-01-01 (effectively all time)